### PR TITLE
Use WordPress address for REST API requests

### DIFF
--- a/includes/Admin/Activation_Notice.php
+++ b/includes/Admin/Activation_Notice.php
@@ -122,16 +122,24 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 		 */
 		unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification, WordPress.VIP.SuperGlobalInputUsage
 
-		$this->assets->enqueue_style( Google_Fonts::SCRIPT_HANDLE );
+                $this->assets->enqueue_style( Google_Fonts::SCRIPT_HANDLE );
 
-		$this->assets->enqueue_script_asset( self::SCRIPT_HANDLE, [ Tracking::SCRIPT_HANDLE ] );
+                $this->assets->enqueue_script_asset( self::SCRIPT_HANDLE, [ Tracking::SCRIPT_HANDLE ] );
 
-		wp_localize_script(
-			self::SCRIPT_HANDLE,
-			'webStoriesActivationSettings',
-			$this->get_script_settings()
-		);
-	}
+                $api_root = trailingslashit( site_url( rest_get_url_prefix() ) );
+                wp_add_inline_script(
+                        self::SCRIPT_HANDLE,
+                        'window.wpApiSettings = window.wpApiSettings || {}; window.wpApiSettings.root = ' .
+                        wp_json_encode( $api_root ) . ';',
+                        'before'
+                );
+
+                wp_localize_script(
+                        self::SCRIPT_HANDLE,
+                        'webStoriesActivationSettings',
+                        $this->get_script_settings()
+                );
+        }
 
 	/**
 	 * Renders the plugin activation notice.

--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -433,13 +433,21 @@ class Dashboard extends Service_Base {
 	 * @param string $hook_suffix The current admin page.
 	 */
 	public function enqueue_assets( string $hook_suffix ): void {
-		if ( $this->get_hook_suffix( 'stories-dashboard' ) !== $hook_suffix ) {
-			return;
-		}
+                if ( $this->get_hook_suffix( 'stories-dashboard' ) !== $hook_suffix ) {
+                        return;
+                }
 
-		$this->assets->enqueue_script_asset( self::SCRIPT_HANDLE, [ Tracking::SCRIPT_HANDLE ], false );
+                $this->assets->enqueue_script_asset( self::SCRIPT_HANDLE, [ Tracking::SCRIPT_HANDLE ], false );
 
-		$this->assets->enqueue_style_asset( self::SCRIPT_HANDLE, [ $this->google_fonts::SCRIPT_HANDLE ] );
+                $api_root = trailingslashit( site_url( rest_get_url_prefix() ) );
+                wp_add_inline_script(
+                        self::SCRIPT_HANDLE,
+                        'window.wpApiSettings = window.wpApiSettings || {}; window.wpApiSettings.root = ' .
+                        wp_json_encode( $api_root ) . ';',
+                        'before'
+                );
+
+                $this->assets->enqueue_style_asset( self::SCRIPT_HANDLE, [ $this->google_fonts::SCRIPT_HANDLE ] );
 
 		wp_localize_script(
 			self::SCRIPT_HANDLE,

--- a/includes/Admin/Editor.php
+++ b/includes/Admin/Editor.php
@@ -312,10 +312,19 @@ class Editor extends Service_Base implements HasRequirements {
 			[],
 			WEBSTORIES_VERSION,
 			true
-		);
+                );
 
-		wp_enqueue_script( self::SCRIPT_HANDLE );
-		$this->assets->enqueue_style_asset( self::SCRIPT_HANDLE, [ $this->google_fonts::SCRIPT_HANDLE ] );
+                wp_enqueue_script( self::SCRIPT_HANDLE );
+
+                $api_root = trailingslashit( site_url( rest_get_url_prefix() ) );
+                wp_add_inline_script(
+                        self::SCRIPT_HANDLE,
+                        'window.wpApiSettings = window.wpApiSettings || {}; window.wpApiSettings.root = ' .
+                        wp_json_encode( $api_root ) . ';',
+                        'before'
+                );
+
+                $this->assets->enqueue_style_asset( self::SCRIPT_HANDLE, [ $this->google_fonts::SCRIPT_HANDLE ] );
 
 		wp_localize_script(
 			self::SCRIPT_HANDLE,

--- a/includes/Admin/TinyMCE.php
+++ b/includes/Admin/TinyMCE.php
@@ -157,15 +157,23 @@ class TinyMCE extends Service_Base {
 	 *
 	 * @since 1.5.0
 	 */
-	public function register_assets(): void {
-		$this->assets->enqueue_style( 'wp-components' );
+        public function register_assets(): void {
+                $this->assets->enqueue_style( 'wp-components' );
 
-		$this->assets->enqueue_script_asset( self::SCRIPT_HANDLE );
-		wp_localize_script(
-			self::SCRIPT_HANDLE,
-			'webStoriesData',
-			$this->stories_script_data->get_script_data()
-		);
+                $this->assets->enqueue_script_asset( self::SCRIPT_HANDLE );
+
+                $api_root = trailingslashit( site_url( rest_get_url_prefix() ) );
+                wp_add_inline_script(
+                        self::SCRIPT_HANDLE,
+                        'window.wpApiSettings = window.wpApiSettings || {}; window.wpApiSettings.root = ' .
+                        wp_json_encode( $api_root ) . ';',
+                        'before'
+                );
+                wp_localize_script(
+                        self::SCRIPT_HANDLE,
+                        'webStoriesData',
+                        $this->stories_script_data->get_script_data()
+                );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- set `wpApiSettings.root` to `site_url()` so plugin UI uses WordPress address for REST calls
- apply the change across dashboard, editor, TinyMCE, and activation notice scripts

## Testing
- `php -l includes/Admin/Editor.php`
- `php -l includes/Admin/Dashboard.php`
- `php -l includes/Admin/Activation_Notice.php`
- `php -l includes/Admin/TinyMCE.php`
- `composer phpcs includes/Admin/Editor.php includes/Admin/Dashboard.php includes/Admin/Activation_Notice.php includes/Admin/TinyMCE.php` *(fails: phpcs not found)*
- `npm test` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace6d0ba98832d82f362ef72b63b10